### PR TITLE
Implement rule "Misuse of Channel Closing Semantics"

### DIFF
--- a/internal/rules/misuse_of_channel_closing_semantics.go
+++ b/internal/rules/misuse_of_channel_closing_semantics.go
@@ -32,7 +32,7 @@ func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, conte
 			if valueArg != nil && valueArg.Type == reader.NodeKeyword && isSentinelKeyword(valueArg.Value) {
 				return &Finding{
 					RuleID:   r.ID,
-					Message:  fmt.Sprintf("Using sentinel value %s in %s to signal stream end. Prefer (close! ch) so that (<! ch) returns nil; avoid custom sentinels.", valueArg.Value, headVal),
+					Message:  fmt.Sprintf("Sentinel value %s in %s: prefer (close! ch) so that (<! ch) returns nil; avoid custom sentinels.", valueArg.Value, headVal),
 					Filepath: filepath,
 					Location: node.Location,
 					Severity: r.Severity,
@@ -56,7 +56,7 @@ func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, conte
 		if sentinel != "" && isChannelTakeForm(other) {
 			return &Finding{
 				RuleID:   r.ID,
-				Message:  fmt.Sprintf("Comparison with sentinel %s; if this signals channel termination, prefer closing the channel with close! and use (when-let [e (<! ch)] ...) so nil means closed.", sentinel),
+				Message:  fmt.Sprintf("Comparison with sentinel %s: prefer (close! ch) so that (<! ch) returns nil; use (when-let [e (<! ch)] ...) when closed.", sentinel),
 				Filepath: filepath,
 				Location: node.Location,
 				Severity: r.Severity,

--- a/internal/rules/misuse_of_channel_closing_semantics.go
+++ b/internal/rules/misuse_of_channel_closing_semantics.go
@@ -47,14 +47,13 @@ func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, conte
 			return nil
 		}
 		a, b := node.Children[1], node.Children[2]
-		sentinel := ""
+		sentinel, other := "", (*reader.RichNode)(nil)
 		if a != nil && a.Type == reader.NodeKeyword && isSentinelKeyword(a.Value) {
-			sentinel = a.Value
+			sentinel, other = a.Value, b
+		} else if b != nil && b.Type == reader.NodeKeyword && isSentinelKeyword(b.Value) {
+			sentinel, other = b.Value, a
 		}
-		if b != nil && b.Type == reader.NodeKeyword && isSentinelKeyword(b.Value) {
-			sentinel = b.Value
-		}
-		if sentinel != "" {
+		if sentinel != "" && isChannelReadOrBinding(other) {
 			return &Finding{
 				RuleID:   r.ID,
 				Message:  fmt.Sprintf("Comparison with sentinel %s; if this signals channel termination, prefer closing the channel with close! and use (when-let [e (<! ch)] ...) so nil means closed.", sentinel),
@@ -74,6 +73,30 @@ func isPutSymbol(s string) bool {
 		return true
 	}
 	return strings.HasSuffix(s, "/put!") || strings.HasSuffix(s, "/>!") || strings.HasSuffix(s, "/>!!")
+}
+
+func isTakeSymbol(s string) bool {
+	switch s {
+	case "<!", "<!!":
+		return true
+	}
+	return strings.HasSuffix(s, "/<!") || strings.HasSuffix(s, "/<!!")
+}
+
+func isChannelReadOrBinding(node *reader.RichNode) bool {
+	if node == nil {
+		return false
+	}
+	if node.Type == reader.NodeSymbol {
+		return true
+	}
+	if node.Type == reader.NodeList && len(node.Children) > 0 {
+		head := node.Children[0]
+		if head != nil && head.Type == reader.NodeSymbol {
+			return isTakeSymbol(head.Value)
+		}
+	}
+	return false
 }
 
 func isSentinelKeyword(v string) bool {

--- a/internal/rules/misuse_of_channel_closing_semantics.go
+++ b/internal/rules/misuse_of_channel_closing_semantics.go
@@ -27,12 +27,12 @@ func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, conte
 	headVal := head.Value
 
 	if isPutSymbol(headVal) {
-		for i := 1; i < len(node.Children); i++ {
-			child := node.Children[i]
-			if child != nil && child.Type == reader.NodeKeyword && isSentinelKeyword(child.Value) {
+		if len(node.Children) >= 3 {
+			valueArg := node.Children[2]
+			if valueArg != nil && valueArg.Type == reader.NodeKeyword && isSentinelKeyword(valueArg.Value) {
 				return &Finding{
 					RuleID:   r.ID,
-					Message:  fmt.Sprintf("Using sentinel value %s in put!/>!/>!! to signal stream end. Prefer (close! ch) so that (<! ch) returns nil; avoid custom sentinels.", child.Value),
+					Message:  fmt.Sprintf("Using sentinel value %s in %s to signal stream end. Prefer (close! ch) so that (<! ch) returns nil; avoid custom sentinels.", valueArg.Value, headVal),
 					Filepath: filepath,
 					Location: node.Location,
 					Severity: r.Severity,
@@ -53,7 +53,7 @@ func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, conte
 		} else if b != nil && b.Type == reader.NodeKeyword && isSentinelKeyword(b.Value) {
 			sentinel, other = b.Value, a
 		}
-		if sentinel != "" && isChannelReadOrBinding(other) {
+		if sentinel != "" && isChannelTakeForm(other) {
 			return &Finding{
 				RuleID:   r.ID,
 				Message:  fmt.Sprintf("Comparison with sentinel %s; if this signals channel termination, prefer closing the channel with close! and use (when-let [e (<! ch)] ...) so nil means closed.", sentinel),
@@ -83,31 +83,47 @@ func isTakeSymbol(s string) bool {
 	return strings.HasSuffix(s, "/<!") || strings.HasSuffix(s, "/<!!")
 }
 
-func isChannelReadOrBinding(node *reader.RichNode) bool {
-	if node == nil {
+func isChannelTakeForm(node *reader.RichNode) bool {
+	if node == nil || node.Type != reader.NodeList || len(node.Children) == 0 {
 		return false
 	}
-	if node.Type == reader.NodeSymbol {
-		return true
+	head := node.Children[0]
+	if head == nil || head.Type != reader.NodeSymbol {
+		return false
 	}
-	if node.Type == reader.NodeList && len(node.Children) > 0 {
-		head := node.Children[0]
-		if head != nil && head.Type == reader.NodeSymbol {
-			return isTakeSymbol(head.Value)
+	return isTakeSymbol(head.Value)
+}
+
+var sentinelStems = []string{
+	"done", "end", "eof", "close", "stop", "exit",
+	"complete", "finish", "eos", "poison", "bye", "quit", "terminat",
+	"closed", "finished", "completed",
+	"synced", "return", "break", 
+}
+
+func isSentinelKeyword(v string) bool {
+	local := keywordLocalName(v)
+	if local == "" {
+		return false
+	}
+	lower := strings.ToLower(local)
+	for _, stem := range sentinelStems {
+		if strings.Contains(lower, stem) {
+			return true
 		}
 	}
 	return false
 }
 
-func isSentinelKeyword(v string) bool {
-	switch v {
-	case ":done", ":EOF", ":end", "::end", ":eof":
-		return true
+func keywordLocalName(kw string) string {
+	s := kw
+	for strings.HasPrefix(s, ":") {
+		s = s[1:]
 	}
-	if strings.HasSuffix(v, "/end") || strings.HasSuffix(v, "/done") || strings.HasSuffix(v, "/eof") {
-		return true
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
 	}
-	return false
+	return s
 }
 
 func init() {
@@ -115,7 +131,7 @@ func init() {
 		Rule: Rule{
 			ID:          "misuse-of-channel-closing-semantics",
 			Name:        "Misuse of Channel Closing Semantics",
-			Description: "Detects using a sentinel value (:done, :EOF, ::end) in put!/>!/>!! or in comparisons to signal channel end; prefer close! and nil from <!.",
+			Description: "Flags keywords that look like stream-end sentinels (done, end, close, stop, complete, etc., word-boundary) in put!/>!/>!! or in comparisons with <!/<!!. Avoids test/placeholder values (:foo, :test-val). Prefer close! and nil from <!.",
 			Severity:    SeverityWarning,
 		},
 	}

--- a/internal/rules/misuse_of_channel_closing_semantics.go
+++ b/internal/rules/misuse_of_channel_closing_semantics.go
@@ -1,0 +1,100 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/thlaurentino/arit/internal/reader"
+)
+
+type MisuseOfChannelClosingSemanticsRule struct {
+	Rule
+}
+
+func (r *MisuseOfChannelClosingSemanticsRule) Meta() Rule {
+	return r.Rule
+}
+
+func (r *MisuseOfChannelClosingSemanticsRule) Check(node *reader.RichNode, context map[string]interface{}, filepath string) *Finding {
+	if node == nil || node.Type != reader.NodeList || len(node.Children) < 2 {
+		return nil
+	}
+
+	head := node.Children[0]
+	if head.Type != reader.NodeSymbol {
+		return nil
+	}
+	headVal := head.Value
+
+	if isPutSymbol(headVal) {
+		for i := 1; i < len(node.Children); i++ {
+			child := node.Children[i]
+			if child != nil && child.Type == reader.NodeKeyword && isSentinelKeyword(child.Value) {
+				return &Finding{
+					RuleID:   r.ID,
+					Message:  fmt.Sprintf("Using sentinel value %s in put!/>!/>!! to signal stream end. Prefer (close! ch) so that (<! ch) returns nil; avoid custom sentinels.", child.Value),
+					Filepath: filepath,
+					Location: node.Location,
+					Severity: r.Severity,
+				}
+			}
+		}
+		return nil
+	}
+
+	if headVal == "not=" || headVal == "=" {
+		if len(node.Children) != 3 {
+			return nil
+		}
+		a, b := node.Children[1], node.Children[2]
+		sentinel := ""
+		if a != nil && a.Type == reader.NodeKeyword && isSentinelKeyword(a.Value) {
+			sentinel = a.Value
+		}
+		if b != nil && b.Type == reader.NodeKeyword && isSentinelKeyword(b.Value) {
+			sentinel = b.Value
+		}
+		if sentinel != "" {
+			return &Finding{
+				RuleID:   r.ID,
+				Message:  fmt.Sprintf("Comparison with sentinel %s; if this signals channel termination, prefer closing the channel with close! and use (when-let [e (<! ch)] ...) so nil means closed.", sentinel),
+				Filepath: filepath,
+				Location: node.Location,
+				Severity: r.Severity,
+			}
+		}
+	}
+
+	return nil
+}
+
+func isPutSymbol(s string) bool {
+	switch s {
+	case "put!", ">!", ">!!":
+		return true
+	}
+	return strings.HasSuffix(s, "/put!") || strings.HasSuffix(s, "/>!") || strings.HasSuffix(s, "/>!!")
+}
+
+func isSentinelKeyword(v string) bool {
+	switch v {
+	case ":done", ":EOF", ":end", "::end", ":eof":
+		return true
+	}
+	if strings.HasSuffix(v, "/end") || strings.HasSuffix(v, "/done") || strings.HasSuffix(v, "/eof") {
+		return true
+	}
+	return false
+}
+
+func init() {
+	defaultRule := &MisuseOfChannelClosingSemanticsRule{
+		Rule: Rule{
+			ID:          "misuse-of-channel-closing-semantics",
+			Name:        "Misuse of Channel Closing Semantics",
+			Description: "Detects using a sentinel value (:done, :EOF, ::end) in put!/>!/>!! or in comparisons to signal channel end; prefer close! and nil from <!.",
+			Severity:    SeverityWarning,
+		},
+	}
+	RegisterRule(defaultRule)
+}

--- a/internal/test/data/misuse_of_channel_closing_semantics.clj
+++ b/internal/test/data/misuse_of_channel_closing_semantics.clj
@@ -41,6 +41,20 @@
 ;; Sentinel with >!! (blocking put)
 (a/thread (a/>!! my-chan :EOF))
 
+;; Comparação com forma de take — deve ser reportada (sentinel em canal)
+(when (= :done (a/<! my-chan)) (prn "channel closed"))
+(when (not= (a/<! my-chan) :end) 1)
+
+;; More sentinels (stem-based): :close, :synced, :return, :break, :hb-terminating
+(a/go (a/put! my-chan :close))
+(a/go (a/put! my-chan :synced))
+(a/go (a/>! my-chan :return))
+(a/thread (a/>!! my-chan :break))
+(a/go (a/put! my-chan :hb-terminating))
+
+;; Should NOT be reported: arbitrary keyword (no stem match)
+(a/go (a/put! my-chan :foo))
+
 ;; --- Correct pattern (should not be reported): close! + when-let with nil ---
 (def ok-chan (a/chan 1))
 (a/go

--- a/internal/test/data/misuse_of_channel_closing_semantics.clj
+++ b/internal/test/data/misuse_of_channel_closing_semantics.clj
@@ -51,3 +51,12 @@
     (when-let [event (a/<! ok-chan)]
       (prn "Processing" event)
       (recur))))
+
+;; --- Should not be reported: :done is alts!! default return, not channel sentinel ---
+(defn drain-channels
+  "Removes all messages from the given channels. Will not block."
+  [channels]
+  (when channels
+    (loop []
+      (when-not (= :done (first (a/alts!! (vec channels) :default :done)))
+        (recur)))))

--- a/internal/test/data/misuse_of_channel_closing_semantics.clj
+++ b/internal/test/data/misuse_of_channel_closing_semantics.clj
@@ -1,0 +1,53 @@
+(ns misuse-of-channel-closing-semantics
+  (:require [clojure.core.async :as a]))
+
+(def my-chan (a/chan 1))
+
+;; Sentinel :done — producer (put!)
+(a/go
+  (a/put! my-chan :done))
+
+;; Sentinel :done — consumer (comparison)
+(a/go
+  (loop []
+    (when-let [event (a/<! my-chan)]
+      (when (not= event :done)
+        (prn "Processing" event)
+        (recur)))))
+
+;; Sentinel :EOF
+(a/go (a/put! my-chan :EOF))
+(when (not= x :EOF) 1)
+
+;; Sentinel :end
+(a/go (a/put! my-chan :end))
+(when (not= event :end) 2)
+
+;; Sentinel ::end
+(a/go (a/put! my-chan ::end))
+(when (not= event ::end) 3)
+
+;; Sentinel :eof
+(a/go (a/put! my-chan :eof))
+(when (not= event :eof) 4)
+
+;; Sentinel :stream/done (namespaced)
+(a/go (a/put! my-chan :stream/done))
+(when (not= event :stream/done) 5)
+
+;; Sentinel with >! (parking put)
+(a/go (a/>! my-chan :done))
+
+;; Sentinel with >!! (blocking put)
+(a/thread (a/>!! my-chan :EOF))
+
+;; --- Correct pattern (should not be reported): close! + when-let with nil ---
+(def ok-chan (a/chan 1))
+(a/go
+  (a/>! ok-chan :some-event)
+  (a/close! ok-chan))
+(a/go
+  (loop []
+    (when-let [event (a/<! ok-chan)]
+      (prn "Processing" event)
+      (recur))))

--- a/internal/test/suite/misuse_of_channel_closing_semantics_test.go
+++ b/internal/test/suite/misuse_of_channel_closing_semantics_test.go
@@ -12,28 +12,24 @@ func TestMisuseOfChannelClosingSemantics(t *testing.T) {
 			FileToAnalyze: "misuse_of_channel_closing_semantics.clj",
 			RuleID:       "misuse-of-channel-closing-semantics",
 			ExpectedFindings: []framework.ExpectedFinding{
-				// Sentinel :done — put! and comparison
-				{Message: "put!", StartLine: 8},
-				{Message: "Comparison with sentinel", StartLine: 14},
-				// Sentinel :EOF
-				{Message: "put!", StartLine: 19},
-				{Message: "Comparison with sentinel", StartLine: 20},
-				// Sentinel :end
-				{Message: "put!", StartLine: 23},
-				{Message: "Comparison with sentinel", StartLine: 24},
-				// Sentinel ::end
-				{Message: "put!", StartLine: 27},
-				{Message: "Comparison with sentinel", StartLine: 28},
-				// Sentinel :eof
-				{Message: "put!", StartLine: 31},
-				{Message: "Comparison with sentinel", StartLine: 32},
-				// Sentinel :stream/done (namespaced)
-				{Message: "put!", StartLine: 35},
-				{Message: "Comparison with sentinel", StartLine: 36},
-				// Sentinel with >! (parking put)
-				{Message: "put!", StartLine: 39},
-				// Sentinel with >!! (blocking put)
-				{Message: "put!", StartLine: 42},
+				// Put: sentinel value (todas usam mensagem "Sentinel value ... in ...")
+				{Message: "Sentinel value", StartLine: 8},
+				{Message: "Sentinel value", StartLine: 19},
+				{Message: "Sentinel value", StartLine: 23},
+				{Message: "Sentinel value", StartLine: 27},
+				{Message: "Sentinel value", StartLine: 31},
+				{Message: "Sentinel value", StartLine: 35},
+				{Message: "Sentinel value", StartLine: 39},
+				{Message: "Sentinel value", StartLine: 42},
+				// Comparison: (= ou not= sentinel take-form)
+				{Message: "Comparison with sentinel", StartLine: 45},
+				{Message: "Comparison with sentinel", StartLine: 46},
+				// More sentinels (stem-based)
+				{Message: "Sentinel value", StartLine: 49},
+				{Message: "Sentinel value", StartLine: 50},
+				{Message: "Sentinel value", StartLine: 51},
+				{Message: "Sentinel value", StartLine: 52},
+				{Message: "Sentinel value", StartLine: 53},
 			},
 		},
 	}

--- a/internal/test/suite/misuse_of_channel_closing_semantics_test.go
+++ b/internal/test/suite/misuse_of_channel_closing_semantics_test.go
@@ -1,0 +1,46 @@
+package suite
+
+import (
+	"testing"
+
+	"github.com/thlaurentino/arit/internal/test/framework"
+)
+
+func TestMisuseOfChannelClosingSemantics(t *testing.T) {
+	testCases := []framework.RuleTestCase{
+		{
+			FileToAnalyze: "misuse_of_channel_closing_semantics.clj",
+			RuleID:       "misuse-of-channel-closing-semantics",
+			ExpectedFindings: []framework.ExpectedFinding{
+				// Sentinel :done — put! and comparison
+				{Message: "put!", StartLine: 8},
+				{Message: "Comparison with sentinel", StartLine: 14},
+				// Sentinel :EOF
+				{Message: "put!", StartLine: 19},
+				{Message: "Comparison with sentinel", StartLine: 20},
+				// Sentinel :end
+				{Message: "put!", StartLine: 23},
+				{Message: "Comparison with sentinel", StartLine: 24},
+				// Sentinel ::end
+				{Message: "put!", StartLine: 27},
+				{Message: "Comparison with sentinel", StartLine: 28},
+				// Sentinel :eof
+				{Message: "put!", StartLine: 31},
+				{Message: "Comparison with sentinel", StartLine: 32},
+				// Sentinel :stream/done (namespaced)
+				{Message: "put!", StartLine: 35},
+				{Message: "Comparison with sentinel", StartLine: 36},
+				// Sentinel with >! (parking put)
+				{Message: "put!", StartLine: 39},
+				// Sentinel with >!! (blocking put)
+				{Message: "put!", StartLine: 42},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.FileToAnalyze, func(t *testing.T) {
+			framework.RunRuleTest(t, tc)
+		})
+	}
+}


### PR DESCRIPTION
# PR: Implement rule "Misuse of Channel Closing Semantics"

## Description

This PR implements a new rule to detect the **Misuse of Channel Closing Semantics** code smell in Clojure projects using `clojure.core.async`.

The smell occurs when a channel-based stream uses a **custom sentinel value** (e.g. `:done`, `:complete`, `:close`) to signal termination instead of relying on the standard core.async contract: closing the channel with `close!` so that subsequent reads (`<!`, `<!!`, `take!`) return `nil`.

**Example of the smell (producer):**

```clojure
(a/put! my-chan :done)   ; or (a/>! my-chan :done) or (a/>!! my-chan :done)
```

**Example of the smell (consumer):**

```clojure
(when (not= event :done)
  (prn "Processing" event)
  (recur))
```

**Recommended pattern:**

```clojure
;; Producer
(a/>! ok-chan :some-event)
(a/close! ok-chan)

;; Consumer — nil from <! means channel closed
(loop []
  (when-let [event (a/<! ok-chan)]
    (prn "Processing" event)
    (recur)))
```

Using sentinels introduces brittle inspection logic and breaks the idiomatic `when-let` + `nil` flow control.

---

## Implementation

The rule analyzes the AST and identifies:

### 1. Put with sentinel

- **Form:** `(put! ch val)` or `(put! ch val callback)` (and namespaced forms: `a/put!`, `async/>!`, `async/>!!`, etc.).
- **Detection:** Only the **value** argument (index 2) is considered. If it is a keyword and matches the sentinel criteria, the rule reports.
- **Sentinel criteria:** The keyword’s **local name** (without `:` and without namespace, e.g. `:my.ns/done` → `"done"`) is checked against a list of **stems**. If the lowercased local name **contains** any stem, it is treated as a sentinel.

  Stems include: `done`, `end`, `eof`, `close`, `stop`, `exit`, `complete`, `finish`, `eos`, `poison`, `bye`, `quit`, `terminat`, `closed`, `finished`, `completed`, `synced`, `return`, `break` (and namespaced variants whose local part contains these, e.g. `:stream/done`, `:hb-terminating`).

  **Arbitrary keywords (e.g. `:aaaaa`, `:foo`) are not flagged** — only those whose name suggests a stream-end or termination meaning (via the stem list) are reported.

- **Why only the value position:** Focusing on the single value put on the channel avoids flagging test/placeholder keywords that often appear in tests and are not stream-end sentinels (see *Refinement* below).

### 2. Comparison with sentinel

- **Form:** `(= x :done)` or `(not= event :done)` (and namespaced `=` / `not=`).
- **Detection:** One side must be a sentinel keyword (same stem-based check as above); the other must be a **channel take form** (`<!` or `<!!`), i.e. a list whose head is `<!` or `<!!`. So we only flag comparisons where one side is a sentinel keyword and the other is an explicit take form (e.g. `(not= (<! ch) :done)`). This avoids false positives when `:done` (or similar) is used as UI/FSM state rather than channel semantics.

**Message:** Findings report the **actual** put/take symbol used (e.g. `"in >!!"`, `"in async/put!"`) instead of a generic `"in put!/>!/>!!"`.

**Rule ID:** `misuse-of-channel-closing-semantics`  
**Severity:** Warning.

---

## Sentinel stems (summary)

| Category        | Stems |
|----------------|-------|
| End / done     | `done`, `end`, `eof`, `closed`, `finished`, `completed` |
| Stop / exit    | `stop`, `exit`, `quit`, `bye`, `break`, `return` |
| Complete       | `complete`, `finish`, `eos`, `terminat` |
| Other          | `poison`, `synced` |

Any keyword whose local name (after stripping `:` and namespace) **contains** one of these stems (case-insensitive) is considered a potential sentinel. **Arbitrary keywords (e.g. `:aaaaa`, `:foo`) are not flagged.**

---

## Refinement based on 142-repository analysis

The rule was tuned using a run over **142 Clojure repositories** to balance precision and recall.

**Avoiding false positives (overly generic sentinels):** An initial version that flagged *any* keyword put on a channel produced many irrelevant findings in tests and examples. Two representative cases that appeared and are now excluded:

1. **`(put! test-channel :foo (fn [_] ...))`** and **`(>!! test-channel :foo)`** in Pulsar’s core.async-style tests — `:foo` is a placeholder value to exercise put/take and callbacks, not a stream-end sentinel.
2. **`(>!! c :full)`** and **`(put! c :enqueues (fn [_] ...))`** in the same test suite — used to “fill up the channel” or “enqueue a put” for buffer behavior; the keywords are test labels, not termination signals.

To avoid these, the rule (a) only considers the **value** argument of put (index 2), and (b) requires the keyword to match the **stem list** above, so generic names like `:foo`, `:test-val`, `:full`, `:enqueues` are not flagged.

**Avoiding false negatives (overly strict rules):** A rigid fixed list of keywords (e.g. only `:done`, `:end`, `:eof`) missed real sentinels such as `:synced`, `:return`, `:hb-terminating`. The stem-based approach (e.g. stems `synced`, `return`, `terminat`) and the value-position check were introduced so that real stream-end signals are still reported without reopening the door to generic placeholders.

---

## Tests

Tests validate the rule for supported sentinels and put/take variants.

**Test file:** `internal/test/data/misuse_of_channel_closing_semantics.clj`

Scenarios:

- Sentinel values: `:done`, `:EOF`, `:end`, `::end`, `:eof`, and namespaced forms (e.g. `:stream/done`).
- Put variants: `put!`, `>!`, `>!!` (and namespaced).
- Consumer comparisons with each sentinel, when the other side is a channel take form.
- A correct pattern (`close!` + `when-let`) that must **not** be reported.

The test checks rule ID, expected finding messages (put vs comparison), line locations, and that the correct-pattern section produces no findings.

---

## Result

The analyzer detects Misuse of Channel Closing Semantics using stem-based sentinel detection and value-position checks, suggests using `close!` and `nil` from `<!`, and — informed by the 142-repository analysis — avoids both false positives (arbitrary or test keywords like `:foo`, `:full`) and false negatives (real sentinels like `:synced`, `:return`). This improves consistency with core.async and discourages custom sentinel protocols.
