### PR TITLE
Initial implementation of the Excessive Refers rule

### DIFF
--- a/internal/rules/excessive_refers.go
+++ b/internal/rules/excessive_refers.go
@@ -1,0 +1,72 @@
+package rules
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/thlaurentino/arit/internal/reader"
+)
+
+const maxRefers = 5
+
+type ExcessiveRefersRule struct {
+	Rule
+}
+
+func (r *ExcessiveRefersRule) Meta() Rule {
+	return r.Rule
+}
+
+func (r *ExcessiveRefersRule) findReferencesNumber(nodes []*reader.RichNode) int{
+    for i, child := range nodes {
+
+        if child.Type == reader.NodeKeyword && strings.Contains(child.Value, "refer") {
+			if i+1 < len(nodes) {
+
+                nextNode := nodes[i+1]
+
+                if nextNode.Type == reader.NodeVector {
+                    return len(nextNode.Children)
+                }
+            }
+        }
+        if len(child.Children) > 0 {
+
+            found := r.findReferencesNumber(child.Children)
+
+            if found != 0 {
+                return found
+            }
+        }
+    }
+    return 0
+}
+
+func (r *ExcessiveRefersRule) Check(node *reader.RichNode, _ map[string]interface{}, filepath string) *Finding {
+	if len(node.Children) <= 0 || node.Children[0].Type != reader.NodeSymbol {
+		return nil
+	}
+	
+	if node.Children[0].Value == "ns" && r.findReferencesNumber(node.Children[1:]) > maxRefers {
+		return &Finding{
+            RuleID:   r.ID,
+            Message:  fmt.Sprintf("The excessive number of explicit references in the %s namespace increases the risk of conflicts with other libraries or with future code.", node.Children[1].Value),
+            Filepath: filepath,
+            Location: node.Location,
+            Severity: r.Severity,
+        }
+	}
+    return nil
+}
+
+func init() {
+	defaultRule := &ExcessiveRefersRule{
+		Rule: Rule{
+			ID:          "excessive-refers",
+			Name:        "Excessive Refers",
+			Description: "Excessive use of explicit references or `refer:all` pollutes the namespace, increasing the risk of collisions.",
+			Severity:    SeverityWarning,
+		},
+	}
+	RegisterRule(defaultRule)
+}


### PR DESCRIPTION
### Initial Implementation of the Excessive References Rule

**Description of Excessive References:** This occurs when a namespace explicitly references a large number of variables (or uses the anti-pattern `:refer :all`) from another namespace. This practice leads to Namespace Pollution, drastically increases the risk of name conflicts with other libraries or future code, and makes the origin of any function call ambiguous.

**Implemented Functions:** `findReferencesNumber`

**How it works:**

1. The Check function searches for the macro `ns` and, if found, calls the findReferencesNumber function passing the current node as a parameter.

2. The findReferencesNumber function receives a RichNode and recursively searches for the occurrence of the keyword `refer`.

3. If found, the function checks if the next node is a NodeVector and, if so, returns its length.

4. The `Check` function verifies if the number of references returned is greater than the `maxRefers` constant.

**Notes:**

- In the future, it should be possible to change the maximum number of references through the tool's settings.

- The use of `refer:all` although mentioned in the code smell description, is not detected by this rule, but rather by the implicit namespace dependencies rule.